### PR TITLE
update to 1.3.11

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,12 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313 : yes
 
+# the conda build parameters to use
+build_parameters:
+  - "--suppress-variables"
+  - "--skip-existing"
+  - "--error-overlinking"
+  - "--no-test"
+
 channels:
   - https://staging.continuum.io/prefect/fs/numpy-feedstock/pr95/abe832a

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes
+
+channels:
+  - https://staging.continuum.io/prefect/fs/numpy-feedstock/pr95/abe832a

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.3.10" %}
+{% set version = "1.3.11" %}
 
 package:
     name: mkl_fft
@@ -6,7 +6,7 @@ package:
 
 source:
     url: https://github.com/IntelPython/mkl_fft/archive/v{{version}}.tar.gz
-    sha256: c519e7baeb609211d1940c5f69e7f6779895fe143f9476282a3dbb2032dd56ad
+    sha256: d881028e1a1a982e7a9b8ad2d56cf0fc3f655579410918c071aee54ae6334511
     patches:
       # setup.py shows dependency on mkl, which we call mkl-service in conda...
       - 0001-install_requires-mkl-service.patch
@@ -31,7 +31,7 @@ requirements:
       - wheel
       - mkl-devel  {{ mkl }}
       - cython 3
-      - numpy-base 2.0.0
+      - numpy-base 2
     run:
       - python
       - mkl


### PR DESCRIPTION
mkl_fft 1.3.11

**Destination channel:** {Snowflake | defaults}

### Links

- PKG-5917
- https://github.com/IntelPython/mkl_fft/tree/v1.3.11

### Explanation of changes:

- Building for numpy 2.1 py313 - tests are skipped because of the circular dependency with numpy.
